### PR TITLE
Code organization and Cocoa conventions

### DIFF
--- a/src/Kube-Solo.xcodeproj/project.pbxproj
+++ b/src/Kube-Solo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		1329DEB61BD4FB5F008AA719 /* update_osx_clients_files.command in Resources */ = {isa = PBXBuildFile; fileRef = 1329DEAB1BD4FB5F008AA719 /* update_osx_clients_files.command */; };
 		1329DEB81BD526A3008AA719 /* update_k8s.command in Resources */ = {isa = PBXBuildFile; fileRef = 1329DEB71BD526A3008AA719 /* update_k8s.command */; };
 		13BCE1C01BEBC0BD00A1A48E /* update_k8s_version.command in Resources */ = {isa = PBXBuildFile; fileRef = 13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */; };
+		CA5B6F621BE15FDC00708D85 /* VMManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5B6F611BE15FDC00708D85 /* VMManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -85,6 +86,8 @@
 		1329DEAB1BD4FB5F008AA719 /* update_osx_clients_files.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_osx_clients_files.command; sourceTree = "<group>"; };
 		1329DEB71BD526A3008AA719 /* update_k8s.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_k8s.command; sourceTree = "<group>"; };
 		13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_k8s_version.command; sourceTree = "<group>"; };
+		CA5B6F601BE15FDC00708D85 /* VMManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMManager.h; sourceTree = "<group>"; };
+		CA5B6F611BE15FDC00708D85 /* VMManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +160,8 @@
 				0133608F18A70E0C0024B1CB /* Kube-Solo.entitlements */,
 				01E2854F18A6C4E300BC630D /* AppDelegate.h */,
 				01E2855018A6C4E300BC630D /* AppDelegate.m */,
+				CA5B6F601BE15FDC00708D85 /* VMManager.h */,
+				CA5B6F611BE15FDC00708D85 /* VMManager.m */,
 				01E2855218A6C4E300BC630D /* MainMenu.xib */,
 				01E2855518A6C4E300BC630D /* Images.xcassets */,
 				01D3685818E5C184006510B5 /* icon.icns */,
@@ -306,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01E2855118A6C4E300BC630D /* AppDelegate.m in Sources */,
+				CA5B6F621BE15FDC00708D85 /* VMManager.m in Sources */,
 				01E2854A18A6C4E300BC630D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/Kube-Solo.xcodeproj/project.pbxproj
+++ b/src/Kube-Solo.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		1329DEB81BD526A3008AA719 /* update_k8s.command in Resources */ = {isa = PBXBuildFile; fileRef = 1329DEB71BD526A3008AA719 /* update_k8s.command */; };
 		13BCE1C01BEBC0BD00A1A48E /* update_k8s_version.command in Resources */ = {isa = PBXBuildFile; fileRef = 13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */; };
 		CA4F6FFF1BE1910A00D87763 /* NSURL+KubeSolo.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4F6FFE1BE1910A00D87763 /* NSURL+KubeSolo.m */; settings = {ASSET_TAGS = (); }; };
+		CA4F70021BE19B8400D87763 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CA4F70001BE19B8400D87763 /* Localizable.strings */; settings = {ASSET_TAGS = (); }; };
 		CA5B6F621BE15FDC00708D85 /* VMManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5B6F611BE15FDC00708D85 /* VMManager.m */; };
 /* End PBXBuildFile section */
 
@@ -89,6 +90,7 @@
 		13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_k8s_version.command; sourceTree = "<group>"; };
 		CA4F6FFD1BE1910A00D87763 /* NSURL+KubeSolo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+KubeSolo.h"; sourceTree = "<group>"; };
 		CA4F6FFE1BE1910A00D87763 /* NSURL+KubeSolo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+KubeSolo.m"; sourceTree = "<group>"; };
+		CA4F70011BE19B8400D87763 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CA5B6F601BE15FDC00708D85 /* VMManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMManager.h; sourceTree = "<group>"; };
 		CA5B6F611BE15FDC00708D85 /* VMManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -183,6 +185,7 @@
 				01E2854918A6C4E300BC630D /* main.m */,
 				01E2854B18A6C4E300BC630D /* Kube-Solo-Prefix.pch */,
 				01E2854C18A6C4E300BC630D /* Credits.rtf */,
+				CA4F70001BE19B8400D87763 /* Localizable.strings */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				019410681BE11DFA00723E19 /* kill_VM.command in Resources */,
 				1329DE921BD4F974008AA719 /* files in Resources */,
 				1329DE901BD4F95F008AA719 /* settings in Resources */,
+				CA4F70021BE19B8400D87763 /* Localizable.strings in Resources */,
 				01E2855418A6C4E300BC630D /* MainMenu.xib in Resources */,
 				01F0282C1A7C54C8008C37AA /* os_shell.command in Resources */,
 				019410661BE119E700723E19 /* go_webserver in Resources */,
@@ -347,6 +351,14 @@
 				01E2855318A6C4E300BC630D /* Base */,
 			);
 			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+		CA4F70001BE19B8400D87763 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CA4F70011BE19B8400D87763 /* en */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/src/Kube-Solo.xcodeproj/project.pbxproj
+++ b/src/Kube-Solo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		1329DEB61BD4FB5F008AA719 /* update_osx_clients_files.command in Resources */ = {isa = PBXBuildFile; fileRef = 1329DEAB1BD4FB5F008AA719 /* update_osx_clients_files.command */; };
 		1329DEB81BD526A3008AA719 /* update_k8s.command in Resources */ = {isa = PBXBuildFile; fileRef = 1329DEB71BD526A3008AA719 /* update_k8s.command */; };
 		13BCE1C01BEBC0BD00A1A48E /* update_k8s_version.command in Resources */ = {isa = PBXBuildFile; fileRef = 13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */; };
+		CA4F6FFF1BE1910A00D87763 /* NSURL+KubeSolo.m in Sources */ = {isa = PBXBuildFile; fileRef = CA4F6FFE1BE1910A00D87763 /* NSURL+KubeSolo.m */; settings = {ASSET_TAGS = (); }; };
 		CA5B6F621BE15FDC00708D85 /* VMManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CA5B6F611BE15FDC00708D85 /* VMManager.m */; };
 /* End PBXBuildFile section */
 
@@ -86,6 +87,8 @@
 		1329DEAB1BD4FB5F008AA719 /* update_osx_clients_files.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_osx_clients_files.command; sourceTree = "<group>"; };
 		1329DEB71BD526A3008AA719 /* update_k8s.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_k8s.command; sourceTree = "<group>"; };
 		13BCE1BF1BEBC0BD00A1A48E /* update_k8s_version.command */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = update_k8s_version.command; sourceTree = "<group>"; };
+		CA4F6FFD1BE1910A00D87763 /* NSURL+KubeSolo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+KubeSolo.h"; sourceTree = "<group>"; };
+		CA4F6FFE1BE1910A00D87763 /* NSURL+KubeSolo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+KubeSolo.m"; sourceTree = "<group>"; };
 		CA5B6F601BE15FDC00708D85 /* VMManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMManager.h; sourceTree = "<group>"; };
 		CA5B6F611BE15FDC00708D85 /* VMManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -162,6 +165,8 @@
 				01E2855018A6C4E300BC630D /* AppDelegate.m */,
 				CA5B6F601BE15FDC00708D85 /* VMManager.h */,
 				CA5B6F611BE15FDC00708D85 /* VMManager.m */,
+				CA4F6FFD1BE1910A00D87763 /* NSURL+KubeSolo.h */,
+				CA4F6FFE1BE1910A00D87763 /* NSURL+KubeSolo.m */,
 				01E2855218A6C4E300BC630D /* MainMenu.xib */,
 				01E2855518A6C4E300BC630D /* Images.xcassets */,
 				01D3685818E5C184006510B5 /* icon.icns */,
@@ -312,6 +317,7 @@
 			files = (
 				01E2855118A6C4E300BC630D /* AppDelegate.m in Sources */,
 				CA5B6F621BE15FDC00708D85 /* VMManager.m in Sources */,
+				CA4F6FFF1BE1910A00D87763 /* NSURL+KubeSolo.m in Sources */,
 				01E2854A18A6C4E300BC630D /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/Kube-Solo/AppDelegate.h
+++ b/src/Kube-Solo/AppDelegate.h
@@ -14,8 +14,8 @@
 @property (strong, nonatomic) IBOutlet NSMenu *statusMenu;
 @property (strong, nonatomic) NSStatusItem *statusItem;
 
-@property(strong) NSWindowController *myWindowController;
+@property (strong) NSWindowController *myWindowController;
 
-@property(strong) NSString *resoucesPathFromApp;
+@property (strong) NSString *resoucesPathFromApp;
 
 @end

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -67,6 +67,8 @@
     }
 }
 
+#pragma mark - Menu Items
+
 - (IBAction)Start:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -158,7 +160,6 @@
     }
 }
 
-// Updates menu
 - (IBAction)update_k8s:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -178,15 +179,16 @@
 
 - (IBAction)update_k8s_version:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl version will be changed"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"update_k8s_version.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_k8s_version.command"]];
             break;
     }
 }
@@ -213,7 +215,6 @@
     [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"fetch_latest_iso.command"]];
 }
 
-// Setup menu
 - (IBAction)changeReleaseChannel:(id)sender {
     [self notifyUserWithText:@"CoreOS release channel change"];
     [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"change_release_channel.command"]];
@@ -261,8 +262,6 @@
     }
 }
 
-// Setup menu
-
 - (IBAction)About:(id)sender {
     NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *app_version = [NSString stringWithFormat:@"%@%@", @"v", version];
@@ -273,7 +272,6 @@
     [self displayWithMessage:mText infoText:infoText];
 }
 
-// VM console
 - (IBAction)attachConsole:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -291,7 +289,6 @@
     }
 }
 
-// OS shell
 - (IBAction)runShell:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -309,7 +306,6 @@
     }
 }
 
-// ssh to VM
 - (IBAction)runSsh:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -327,7 +323,6 @@
     }
 }
 
-// UI
 - (IBAction)fleetUI:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
 
@@ -421,7 +416,26 @@
     exit(0);
 }
 
-// helping functions
+#pragma mark - NSUserNotificationCenterDelegate
+
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
+     shouldPresentNotification:(NSUserNotification *)notification {
+    return YES;
+}
+
+#pragma mark - Helpers
+
+- (void)notifyUserWithTitle:(NSString *_Nullable)title text:(NSString *_Nullable)text {
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+
+    notification.title = title;
+    notification.informativeText = text;
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
+- (void)notifyUserWithText:(NSString *_Nullable)text {
+    [self notifyUserWithTitle:@"Kube Solo" text:text];
+}
 - (void)runScript:(NSString *)scriptName arguments:(NSString *)arguments {
     NSTask *task = [[NSTask alloc] init];
 
@@ -443,27 +457,6 @@
     [alert setMessageText:mText];
     [alert setInformativeText:infoText];
     [alert runModal];
-}
-
-#pragma mark - NSUserNotificationCenterDelegate
-
-- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
-     shouldPresentNotification:(NSUserNotification *)notification {
-    return YES;
-}
-
-#pragma mark -
-
-- (void)notifyUserWithTitle:(NSString *_Nullable)title text:(NSString *_Nullable)text {
-    NSUserNotification *notification = [[NSUserNotification alloc] init];
-
-    notification.title = title;
-    notification.informativeText = text;
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
-}
-
-- (void)notifyUserWithText:(NSString *_Nullable)text {
-    [self notifyUserWithTitle:@"Kube Solo" text:text];
 }
 
 @end

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -29,10 +29,6 @@
     [self.statusItem setImage: [NSImage imageNamed:@"StatusItemIcon"]];
     [self.statusItem setHighlightMode:YES];
     
-    // get the App's main bundle path
-    _resoucesPathFromApp = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@""];
-    NSLog(@"applicationDirectory: '%@'", _resoucesPathFromApp);
-
     NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
     
     BOOL isDir;
@@ -40,7 +36,7 @@
     // if kube-solo folder exists
     {
         // set resouces_path
-        NSString *resources_content = _resoucesPathFromApp;
+        NSString *resources_content = [[NSBundle mainBundle] resourcePath];
         NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
                                                 contents:fileContents1
@@ -89,7 +85,7 @@
             if([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir)
             {
                 [self notifyUserWithTitle:@"Kube Solo will be up shortly" text:@"and OS shell will be opened"];
-                [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"up.command"]];
+                [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"up.command"]];
             }
             else
             {
@@ -161,7 +157,7 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithText:@"VM will be reloaded"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"reload.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"reload.command"]];
             break;
     }
 }
@@ -177,7 +173,7 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl will be updated"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"update_k8s.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_k8s.command"]];
             break;
     }
 }
@@ -207,26 +203,26 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithText:@"OS X clients will be updated"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"update_osx_clients_files.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_osx_clients_files.command"]];
             break;
     }
 }
 
 - (IBAction)fetchLatestISO:(id)sender {
     [self notifyUserWithText:@"CoreOS ISO image will be updated"];
-    [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"fetch_latest_iso.command"]];
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"fetch_latest_iso.command"]];
 }
 
 // Setup menu
 - (IBAction)changeReleaseChannel:(id)sender {
     [self notifyUserWithText:@"CoreOS release channel change"];
-    [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"change_release_channel.command"]];
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"change_release_channel.command"]];
 }
 
 
 - (IBAction)destroy:(id)sender {
     [self notifyUserWithText:@"VM will be destroyed"];
-    [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"destroy.command"]];
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"destroy.command"]];
     [self.vmManager showVMStatus];
 }
 
@@ -258,16 +254,13 @@
                                                 contents:app_version
                                               attributes:nil];
         // set resouces_path
-        NSString *resources_content = _resoucesPathFromApp;
+        NSString *resources_content = [[NSBundle mainBundle] resourcePath];
         NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
                                                 contents:fileContents1
                                               attributes:nil];
         
-        // run install script
-        NSString *scriptName = [[NSString alloc] init];
-        NSString *arguments = [[NSString alloc] init];
-        [self runScript:scriptName = @"kube-solo-install" arguments:arguments = _resoucesPathFromApp ];
+        [self runScript:@"kube-solo-install" arguments:[[NSBundle mainBundle] resourcePath]];
     }
 }
 // Setup menu
@@ -292,7 +285,7 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithText:@"VM's console will be opened"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"console.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"console.command"]];
             break;
     }
 }
@@ -308,7 +301,7 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithText:@"OS X shell will be opened"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"os_shell.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"os_shell.command"]];
             break;
     }
 }
@@ -324,7 +317,7 @@
         case VMStatusUp:
             NSLog (@"VM is On");
             [self notifyUserWithText:@"VM ssh shell will be opened"];
-            [self runApp:@"iTerm" arguments:[_resoucesPathFromApp stringByAppendingPathComponent:@"ssh.command"]];
+            [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"ssh.command"]];
             break;
     }
 }

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -40,10 +40,10 @@
     }
     else {
         NSAlert *alert = [[NSAlert alloc] init];
-        [alert addButtonWithTitle:@"OK"];
-        [alert addButtonWithTitle:@"Cancel"];
-        [alert setMessageText:@"Kube-Solo was not set."];
-        [alert setInformativeText:@"Do you want to set it up?"];
+        [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
+        [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+        [alert setMessageText:NSLocalizedString(@"NotSetupAlertMessage", nil)];
+        [alert setInformativeText:NSLocalizedString(@"NotSetupAlertInformativeText", nil)];
         [alert setAlertStyle:NSWarningAlertStyle];
 
         if ([alert runModal] == NSAlertFirstButtonReturn) {
@@ -52,8 +52,7 @@
         }
         else {
             // Cancel clicked
-            NSString *msg = [NSString stringWithFormat:@"%@ ", @" 'Initial setup of Kube-Solo' at any time later one !!! "];
-            [self displayWithMessage:@"You can set Kube-Solo from menu 'Setup':" infoText:msg];
+            [self alertWithMessage:NSLocalizedString(@"SetupAlertMessage", nil) infoText:NSLocalizedString(@"SetupAlertInformativeText", nil)];
         }
     }
 }
@@ -67,15 +66,15 @@
         case VMStatusDown: {
             BOOL isDir;
             if ([[NSFileManager defaultManager] fileExistsAtPath:[[NSURL ks_homeURL] path] isDirectory:&isDir] && isDir) {
-                [self notifyUserWithTitle:@"Kube Solo will be up shortly" text:@"and OS shell will be opened"];
+                [self notifyUserWithTitle:NSLocalizedString(@"WillSetupNotificationTitle", nil) text:NSLocalizedString(@"WillSetupNotificationMessage", nil)];
                 [self.vmManager start];
             }
             else {
                 NSAlert *alert = [[NSAlert alloc] init];
-                [alert addButtonWithTitle:@"OK"];
-                [alert addButtonWithTitle:@"Cancel"];
-                [alert setMessageText:@"Kube Solo was not set."];
-                [alert setInformativeText:@"Do you want to set it up?"];
+                [alert addButtonWithTitle:NSLocalizedString(@"OK", nil)];
+                [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
+                [alert setMessageText:NSLocalizedString(@"NotSetupAlertMessage", nil)];
+                [alert setInformativeText:NSLocalizedString(@"NotSetupAlertInformativeText", nil)];
                 [alert setAlertStyle:NSWarningAlertStyle];
 
                 if ([alert runModal] == NSAlertFirstButtonReturn) {
@@ -84,8 +83,7 @@
                 }
                 else {
                     // Cancel clicked
-                    NSString *msg = [NSString stringWithFormat:@"%@ ", @" 'Initial setup of Kube Solo' at any time later one !!! "];
-                    [self displayWithMessage:@"You can set VM from menu 'Setup':" infoText:msg];
+                    [self alertWithMessage:NSLocalizedString(@"SetupAlertMessage", nil) infoText:NSLocalizedString(@"SetupAlertInformativeText", nil)];
                 }
             }
 
@@ -93,7 +91,7 @@
         }
 
         case VMStatusUp:
-            [self notifyUserWithText:@"VM is already running !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateRunning", nil)];
             break;
     }
 }
@@ -103,18 +101,18 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is already Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateAlreadyOff", nil)];
             break;
         case VMStatusUp:
-            [self notifyUserWithText:@"VM will be stopped"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateWillStop", nil)];
             [self.vmManager halt];
-            [self notifyUserWithText:@"VM is stopping !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateStopping", nil)];
 
             VMStatus vmStatusCheck = VMStatusUp;
             while (vmStatusCheck == VMStatusUp) {
                 vmStatusCheck = [self.vmManager checkVMStatus];
                 if (vmStatusCheck == VMStatusDown) {
-                    [self notifyUserWithText:@"VM is OFF !!!"];
+                    [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
                     break;
                 }
                 else {
@@ -130,11 +128,11 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"VM will be reloaded"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateWillReload", nil)];
             [self.vmManager reload];
             break;
     }
@@ -145,11 +143,11 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl will be updated"];
+            [self notifyUserWithTitle:NSLocalizedString(@"KubernetesUpdateNotificationTitle", nil) text:NSLocalizedString(@"KubernetedUpdateNotificationMessage", nil)];
             [self.vmManager updateKubernetes];
             break;
     }
@@ -160,12 +158,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
         case VMStatusUp:
-            NSLog(@"VM is On");
-            [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl version will be changed"];
+            [self notifyUserWithTitle:NSLocalizedString(@"KubernetesUpdateNotificationTitle", nil) text:NSLocalizedString(@"KubernetesVersionChangeNotificationMessage", nil)];
             [self.vmManager updateKubernetesVersion];
             break;
     }
@@ -176,36 +172,36 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"OS X clients will be updated"];
+            [self notifyUserWithText:NSLocalizedString(@"ClientsWillBeUpdatedNotificationMessage", nil)];
             [self.vmManager updateClients];
             break;
     }
 }
 
 - (IBAction)fetchLatestISO:(id)sender {
-    [self notifyUserWithText:@"CoreOS ISO image will be updated"];
+    [self notifyUserWithText:NSLocalizedString(@"ISOImageWillBeUpdatedNotificationMessage", nil)];
     [self.vmManager updateISO];
 }
 
 - (IBAction)changeReleaseChannel:(id)sender {
-    [self notifyUserWithText:@"CoreOS release channel change"];
+    [self notifyUserWithText:NSLocalizedString(@"ReleaseChannelChangeNotificationMessage", nil)];
     [self.vmManager changeReleaseChannel];
 }
 
 - (IBAction)destroy:(id)sender {
-    [self notifyUserWithText:@"VM will be destroyed"];
+    [self notifyUserWithText:NSLocalizedString(@"VMStateWillDestroy", nil)];
     [self.vmManager destroy];
     VMStatus status = [self.vmManager checkVMStatus];
     switch (status) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is stopped"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateStopped", nil)];
             break;
         case VMStatusUp:
-            [self notifyUserWithText:@"VM is running"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateRunning", nil)];
             break;
     }
 }
@@ -213,8 +209,8 @@
 - (IBAction)initialInstall:(id)sender {
     BOOL isDir;
     if ([[NSFileManager defaultManager] fileExistsAtPath:[[NSURL ks_homeURL] path] isDirectory:&isDir] && isDir) {
-        NSString *msg = [NSString stringWithFormat:@"%@ %@ %@", @"Folder", [[NSURL ks_homeURL] path], @"exists, please delete or rename that folder !!!"];
-        [self displayWithMessage:@"Kube-Solo" infoText:msg];
+        NSString *msg = [NSString stringWithFormat:NSLocalizedString(@"HomeFolderExistsAlertInformativeText", nil), [[NSURL ks_homeURL] path]];
+        [self alertWithMessage:NSLocalizedString(@"AppName", nil) infoText:msg];
     }
     else {
         NSLog(@"Folder does not exist: '%@'", [NSURL ks_homeURL]);
@@ -232,12 +228,10 @@
 
 - (IBAction)About:(id)sender {
     NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    NSString *appVersion = [NSString stringWithFormat:@"%@%@", @"v", version];
+    NSString *message = [NSString stringWithFormat:NSLocalizedString(@"AboutAlertMessage", nil), version];
+    NSString *infoText = NSLocalizedString(@"AboutInformativeText", nil);
 
-    NSString *message = [NSString stringWithFormat:@"%@ %@", @"Kube-Solo for OS X", appVersion];
-    NSString *infoText = @"It is a simple wrapper around xhyve + CoreOS VM, which allows to control Kube-Solo via Status Bar !!!";
-
-    [self displayWithMessage:message infoText:infoText];
+    [self alertWithMessage:message infoText:infoText];
 }
 
 - (IBAction)attachConsole:(id)sender {
@@ -245,11 +239,11 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"VM's console will be opened"];
+            [self notifyUserWithText:NSLocalizedString(@"ConsoleWillOpenNotificationMessage", nil)];
             [self.vmManager attachConsole];
             break;
     }
@@ -260,11 +254,11 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"OS X shell will be opened"];
+            [self notifyUserWithText:NSLocalizedString(@"ShellWillOpenNotificationMessage", nil)];
             [self.vmManager runShell];
             break;
     }
@@ -275,11 +269,11 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"VM ssh shell will be opened"];
+            [self notifyUserWithText:NSLocalizedString(@"SSHShellWillOpenNotificationMessage", nil)];
             [self.vmManager runSSH];
             break;
     }
@@ -290,14 +284,15 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
-        case VMStatusUp:
+        case VMStatusUp: {
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:3000", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
+        }
     }
 }
 
@@ -306,14 +301,15 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
-        case VMStatusUp:
+        case VMStatusUp: {
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:8080/ui", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
+        }
     }
 }
 
@@ -322,14 +318,15 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            [self notifyUserWithText:@"VM is Off !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
             break;
 
-        case VMStatusUp:
+        case VMStatusUp: {
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:4194", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
+        }
     }
 }
 
@@ -341,15 +338,15 @@
             break;
 
         case VMStatusUp:
-            [self notifyUserWithText:@"VM will be stopped"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateWillStop", nil)];
             [self.vmManager halt];
-            [self notifyUserWithText:@"VM is stopping !!!"];
+            [self notifyUserWithText:NSLocalizedString(@"VMStateStopping", nil)];
 
             VMStatus vmStatusCheck = VMStatusUp;
             while (vmStatusCheck == VMStatusUp) {
                 vmStatusCheck = [self.vmManager checkVMStatus];
                 if (vmStatusCheck == VMStatusDown) {
-                    [self notifyUserWithText:@"VM is OFF !!!"];
+                    [self notifyUserWithText:NSLocalizedString(@"VMStateOff", nil)];
                     break;
                 }
                 else {
@@ -359,7 +356,7 @@
             break;
     }
 
-    [self notifyUserWithTitle:@"Quitting Kube-Solo App" text:@""];
+    [self notifyUserWithTitle:NSLocalizedString(@"QuittingNotificationTitle", nil) text:nil];
 
     [[NSApplication sharedApplication] terminate:self];
 }
@@ -382,14 +379,14 @@
 }
 
 - (void)notifyUserWithText:(NSString *_Nullable)text {
-    [self notifyUserWithTitle:@"Kube Solo" text:text];
+    [self notifyUserWithTitle:NSLocalizedString(@"AppName", nil) text:text];
 }
 
-- (void)displayWithMessage:(NSString *)mText infoText:(NSString *)infoText {
+- (void)alertWithMessage:(NSString *)message infoText:(NSString *)infoText {
     NSAlert *alert = [[NSAlert alloc] init];
 
     [alert setAlertStyle:NSInformationalAlertStyle];
-    [alert setMessageText:mText];
+    [alert setMessageText:message];
     [alert setInformativeText:infoText];
     [alert runModal];
 }

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -27,24 +27,15 @@
     [self.statusItem setImage: [NSImage imageNamed:@"StatusItemIcon"]];
     [self.statusItem setHighlightMode:YES];
 
-    NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
-
+    NSString *homeDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
     BOOL isDir;
-    if ([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
-        // if kube-solo folder exists
-        // set resouces_path
-        NSString *resources_content = [[NSBundle mainBundle] resourcePath];
-        NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
-        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
-         contents:fileContents1
-         attributes:nil];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:homeDirectory isDirectory:&isDir] && isDir) {
+        NSData *resourceData = [[[NSBundle mainBundle] resourcePath] dataUsingEncoding:NSUTF8StringEncoding];
+        [[NSFileManager defaultManager] createFileAtPath:[homeDirectory stringByAppendingPathComponent:@".env/resouces_path"] contents:resourceData attributes:nil];
 
-        // write to file App version
         NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        NSData *app_version = [version dataUsingEncoding:NSUTF8StringEncoding];
-        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/version"]
-         contents:app_version
-         attributes:nil];
+        NSData *appVersion = [version dataUsingEncoding:NSUTF8StringEncoding];
+        [[NSFileManager defaultManager] createFileAtPath:[homeDirectory stringByAppendingPathComponent:@".env/version"] contents:appVersion attributes:nil];
         [self.vmManager checkVMStatus];
     }
     else {
@@ -75,10 +66,10 @@
     switch (vmStatus) {
         case VMStatusDown: {
             NSLog(@"VM is Off");
-            NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
+            NSString *homeDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
 
             BOOL isDir;
-            if ([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
+            if ([[NSFileManager defaultManager] fileExistsAtPath:homeDirectory isDirectory:&isDir] && isDir) {
                 [self notifyUserWithTitle:@"Kube Solo will be up shortly" text:@"and OS shell will be opened"];
                 [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"up.command"]];
             }
@@ -227,36 +218,24 @@
 }
 
 - (IBAction)initialInstall:(id)sender {
-    NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
-
+    NSString *homeDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
     BOOL isDir;
-
-    if ([[NSFileManager defaultManager]
-         fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
-        NSString *msg = [NSString stringWithFormat:@"%@ %@ %@", @"Folder", home_folder, @"exists, please delete or rename that folder !!!"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:homeDirectory isDirectory:&isDir] && isDir) {
+        NSString *msg = [NSString stringWithFormat:@"%@ %@ %@", @"Folder", homeDirectory, @"exists, please delete or rename that folder !!!"];
         [self displayWithMessage:@"Kube-Solo" infoText:msg];
     }
     else {
-        NSLog(@"Folder does not exist: '%@'", home_folder);
-        // create home folder and .env subfolder
-        NSString *env_folder = [home_folder stringByAppendingPathComponent:@".env"];
-        NSError *error = nil;
-        [[NSFileManager defaultManager] createDirectoryAtPath:env_folder
-         withIntermediateDirectories:YES
-         attributes:nil
-         error:&error];
-        // write to file App version
+        NSLog(@"Folder does not exist: '%@'", homeDirectory);
+        NSString *envDirectory = [homeDirectory stringByAppendingPathComponent:@".env"];
+        NSError *error;
+        [[NSFileManager defaultManager] createDirectoryAtPath:envDirectory withIntermediateDirectories:YES attributes:nil error:&error];
+
         NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-        NSData *app_version = [version dataUsingEncoding:NSUTF8StringEncoding];
-        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/version"]
-         contents:app_version
-         attributes:nil];
-        // set resouces_path
-        NSString *resources_content = [[NSBundle mainBundle] resourcePath];
-        NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
-        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
-         contents:fileContents1
-         attributes:nil];
+        NSData *appVersion = [version dataUsingEncoding:NSUTF8StringEncoding];
+        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/version"] contents:appVersion attributes:nil];
+
+        NSData *resourcesPath = [[[NSBundle mainBundle] resourcePath] dataUsingEncoding:NSUTF8StringEncoding];
+        [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"] contents:resourcesPath attributes:nil];
 
         [self runScript:@"kube-solo-install" arguments:[[NSBundle mainBundle] resourcePath]];
     }
@@ -264,12 +243,12 @@
 
 - (IBAction)About:(id)sender {
     NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-    NSString *app_version = [NSString stringWithFormat:@"%@%@", @"v", version];
+    NSString *appVersion = [NSString stringWithFormat:@"%@%@", @"v", version];
 
-    NSString *mText = [NSString stringWithFormat:@"%@ %@", @"Kube-Solo for OS X", app_version];
+    NSString *message = [NSString stringWithFormat:@"%@ %@", @"Kube-Solo for OS X", appVersion];
     NSString *infoText = @"It is a simple wrapper around xhyve + CoreOS VM, which allows to control Kube-Solo via Status Bar !!!";
 
-    [self displayWithMessage:mText infoText:infoText];
+    [self displayWithMessage:message infoText:infoText];
 }
 
 - (IBAction)attachConsole:(id)sender {
@@ -334,10 +313,10 @@
 
         case VMStatusUp:
             NSLog(@"VM is On");
-            NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
+            NSString *filePath = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
-            NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://", vm_ip, @":3000"] componentsJoinedByString : @""];
+            NSString *vmIP = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
+            NSString *url = [@[@"http://", vmIP, @":3000"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }
@@ -354,10 +333,10 @@
 
         case VMStatusUp:
             NSLog(@"VM is On");
-            NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
+            NSString *filePath = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
-            NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://", vm_ip, @":8080/ui"] componentsJoinedByString : @""];
+            NSString *vmIP = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
+            NSString *url = [@[@"http://", vmIP, @":8080/ui"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }
@@ -374,10 +353,10 @@
 
         case VMStatusUp:
             NSLog(@"VM is On");
-            NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
+            NSString *filePath = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
-            NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://", vm_ip, @":4194"] componentsJoinedByString : @""];
+            NSString *vmIP = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:NULL];
+            NSString *url = [@[@"http://", vmIP, @":4194"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -385,7 +385,7 @@
 
     [self notifyUserWithTitle:@"Quitting Kube-Solo App" text:@""];
 
-    exit(0);
+    [[NSApplication sharedApplication] terminate:self];
 }
 
 #pragma mark - NSUserNotificationCenterDelegate

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -17,55 +17,49 @@
 
 @implementation AppDelegate
 
-
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
-{
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 
     self.vmManager = [[VMManager alloc] init];
-    
+
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     [self.statusItem setMenu:self.statusMenu];
     [self.statusItem setImage: [NSImage imageNamed:@"StatusItemIcon"]];
     [self.statusItem setHighlightMode:YES];
-    
+
     NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
-    
+
     BOOL isDir;
-    if([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir)
-    // if kube-solo folder exists
-    {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
+        // if kube-solo folder exists
         // set resouces_path
         NSString *resources_content = [[NSBundle mainBundle] resourcePath];
         NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
-                                                contents:fileContents1
-                                              attributes:nil];
+         contents:fileContents1
+         attributes:nil];
 
         // write to file App version
         NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         NSData *app_version = [version dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/version"]
-                                                contents:app_version
-                                              attributes:nil];
+         contents:app_version
+         attributes:nil];
         [self.vmManager checkVMStatus];
-            
     }
-    else
-    {
+    else {
         NSAlert *alert = [[NSAlert alloc] init];
         [alert addButtonWithTitle:@"OK"];
         [alert addButtonWithTitle:@"Cancel"];
         [alert setMessageText:@"Kube-Solo was not set."];
         [alert setInformativeText:@"Do you want to set it up?"];
         [alert setAlertStyle:NSWarningAlertStyle];
-        
+
         if ([alert runModal] == NSAlertFirstButtonReturn) {
             // OK clicked
             [self initialInstall:self];
         }
-        else
-        {
+        else {
             // Cancel clicked
             NSString *msg = [NSString stringWithFormat:@"%@ ", @" 'Initial setup of Kube-Solo' at any time later one !!! "];
             [self displayWithMessage:@"You can set Kube-Solo from menu 'Setup':" infoText:msg];
@@ -73,44 +67,43 @@
     }
 }
 
-
 - (IBAction)Start:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown: {
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
-            
+
             BOOL isDir;
-            if([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir)
-            {
+            if ([[NSFileManager defaultManager] fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
                 [self notifyUserWithTitle:@"Kube Solo will be up shortly" text:@"and OS shell will be opened"];
                 [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"up.command"]];
             }
-            else
-            {
+            else {
                 NSAlert *alert = [[NSAlert alloc] init];
                 [alert addButtonWithTitle:@"OK"];
                 [alert addButtonWithTitle:@"Cancel"];
                 [alert setMessageText:@"Kube Solo was not set."];
                 [alert setInformativeText:@"Do you want to set it up?"];
                 [alert setAlertStyle:NSWarningAlertStyle];
-                
+
                 if ([alert runModal] == NSAlertFirstButtonReturn) {
                     // OK clicked
                     [self initialInstall:self];
                 }
-                else
-                {
+                else {
                     // Cancel clicked
                     NSString *msg = [NSString stringWithFormat:@"%@ ", @" 'Initial setup of Kube Solo' at any time later one !!! "];
                     [self displayWithMessage:@"You can set VM from menu 'Setup':" infoText:msg];
                 }
             }
+
             break;
         }
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM is already running !!!"];
             break;
     }
@@ -118,13 +111,15 @@
 
 - (IBAction)Stop:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is already Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be stopped"];
 
             [self runScript:@"halt" arguments:@""];
@@ -138,8 +133,7 @@
                     [self notifyUserWithText:@"VM is OFF !!!"];
                     break;
                 }
-                else
-                {
+                else {
                     [self runScript:@"kill_VM" arguments:@""];
                 }
             }
@@ -148,14 +142,16 @@
 }
 
 - (IBAction)Restart:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be reloaded"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"reload.command"]];
             break;
@@ -164,14 +160,16 @@
 
 // Updates menu
 - (IBAction)update_k8s:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl will be updated"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_k8s.command"]];
             break;
@@ -195,13 +193,15 @@
 
 - (IBAction)updates:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"OS X clients will be updated"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_osx_clients_files.command"]];
             break;
@@ -219,71 +219,72 @@
     [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"change_release_channel.command"]];
 }
 
-
 - (IBAction)destroy:(id)sender {
     [self notifyUserWithText:@"VM will be destroyed"];
     [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"destroy.command"]];
     [self.vmManager showVMStatus];
 }
 
-
-- (IBAction)initialInstall:(id)sender
-{
+- (IBAction)initialInstall:(id)sender {
     NSString *home_folder = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo"];
-    
+
     BOOL isDir;
-    if([[NSFileManager defaultManager]
-        fileExistsAtPath:home_folder isDirectory:&isDir] && isDir){
+
+    if ([[NSFileManager defaultManager]
+         fileExistsAtPath:home_folder isDirectory:&isDir] && isDir) {
         NSString *msg = [NSString stringWithFormat:@"%@ %@ %@", @"Folder", home_folder, @"exists, please delete or rename that folder !!!"];
         [self displayWithMessage:@"Kube-Solo" infoText:msg];
     }
-    else
-    {
+    else {
         NSLog(@"Folder does not exist: '%@'", home_folder);
         // create home folder and .env subfolder
         NSString *env_folder = [home_folder stringByAppendingPathComponent:@".env"];
-        NSError * error = nil;
+        NSError *error = nil;
         [[NSFileManager defaultManager] createDirectoryAtPath:env_folder
-                                  withIntermediateDirectories:YES
-                                                   attributes:nil
-                                                        error:&error];
+         withIntermediateDirectories:YES
+         attributes:nil
+         error:&error];
         // write to file App version
         NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
         NSData *app_version = [version dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/version"]
-                                                contents:app_version
-                                              attributes:nil];
+         contents:app_version
+         attributes:nil];
         // set resouces_path
         NSString *resources_content = [[NSBundle mainBundle] resourcePath];
         NSData *fileContents1 = [resources_content dataUsingEncoding:NSUTF8StringEncoding];
         [[NSFileManager defaultManager] createFileAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/resouces_path"]
-                                                contents:fileContents1
-                                              attributes:nil];
-        
+         contents:fileContents1
+         attributes:nil];
+
         [self runScript:@"kube-solo-install" arguments:[[NSBundle mainBundle] resourcePath]];
     }
 }
+
 // Setup menu
 
 - (IBAction)About:(id)sender {
     NSString *version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *app_version = [NSString stringWithFormat:@"%@%@", @"v", version];
-    
+
     NSString *mText = [NSString stringWithFormat:@"%@ %@", @"Kube-Solo for OS X", app_version];
     NSString *infoText = @"It is a simple wrapper around xhyve + CoreOS VM, which allows to control Kube-Solo via Status Bar !!!";
+
     [self displayWithMessage:mText infoText:infoText];
 }
 
 // VM console
 - (IBAction)attachConsole:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM's console will be opened"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"console.command"]];
             break;
@@ -291,15 +292,17 @@
 }
 
 // OS shell
-- (IBAction)runShell:(id)sender{
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+- (IBAction)runShell:(id)sender {
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"OS X shell will be opened"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"os_shell.command"]];
             break;
@@ -308,14 +311,16 @@
 
 // ssh to VM
 - (IBAction)runSsh:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM ssh shell will be opened"];
             [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"ssh.command"]];
             break;
@@ -324,54 +329,60 @@
 
 // UI
 - (IBAction)fleetUI:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
             NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://",vm_ip,@":3000"] componentsJoinedByString:@""];
+            NSString *url = [@[@"http://", vm_ip, @":3000"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }
 }
 
 - (IBAction)KubernetesUI:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
             NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://",vm_ip,@":8080/ui"] componentsJoinedByString:@""];
+            NSString *url = [@[@"http://", vm_ip, @":8080/ui"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }
 }
 
 - (IBAction)node1_cAdvisor:(id)sender {
-    VMStatus vmStatus=[self.vmManager checkVMStatus];
+    VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
+
         case VMStatusUp:
-            NSLog (@"VM is On");
+            NSLog(@"VM is On");
             NSString *file_path = [NSHomeDirectory() stringByAppendingPathComponent:@"kube-solo/.env/ip_address"];
             // read IP from file
             NSString *vm_ip = [NSString stringWithContentsOfFile:file_path encoding:NSUTF8StringEncoding error:NULL];
-            NSString *url = [@[@"http://",vm_ip,@":4194"] componentsJoinedByString:@""];
+            NSString *url = [@[@"http://", vm_ip, @":4194"] componentsJoinedByString : @""];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
             break;
     }
@@ -379,16 +390,18 @@
 
 - (IBAction)quit:(id)sender {
     VMStatus vmStatus = [self.vmManager checkVMStatus];
+
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog (@"VM is Off");
+            NSLog(@"VM is Off");
             break;
+
         case VMStatusUp:
-        NSLog (@"VM is On");
+            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be stopped"];
-        [self runScript:@"halt" arguments:@""];
+            [self runScript:@"halt" arguments:@""];
             [self notifyUserWithText:@"VM is stopping !!!"];
-            
+
             VMStatus vmStatusCheck = VMStatusUp;
             while (vmStatusCheck == VMStatusUp) {
                 vmStatusCheck = [self.vmManager checkVMStatus];
@@ -396,8 +409,7 @@
                     [self notifyUserWithText:@"VM is OFF !!!"];
                     break;
                 }
-                else
-                {
+                else {
                     [self runScript:@"kill_VM" arguments:@""];
                 }
             }
@@ -410,25 +422,23 @@
 }
 
 // helping functions
-- (void)runScript:(NSString*)scriptName arguments:(NSString*)arguments
-{
+- (void)runScript:(NSString *)scriptName arguments:(NSString *)arguments {
     NSTask *task = [[NSTask alloc] init];
+
     task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:scriptName ofType:@"command"]];
     task.arguments  = @[arguments];
     [task launch];
     [task waitUntilExit];
-    
 }
 
-- (void)runApp:(NSString*)appName arguments:(NSString*)arguments
-{
+- (void)runApp:(NSString *)appName arguments:(NSString *)arguments {
     // lunch an external App from the mainBundle
     [[NSWorkspace sharedWorkspace] openFile:arguments withApplication:appName];
 }
 
--(void) displayWithMessage:(NSString *)mText infoText:(NSString*)infoText
-{
+- (void)displayWithMessage:(NSString *)mText infoText:(NSString *)infoText {
     NSAlert *alert = [[NSAlert alloc] init];
+
     [alert setAlertStyle:NSInformationalAlertStyle];
     [alert setMessageText:mText];
     [alert setInformativeText:infoText];
@@ -438,21 +448,21 @@
 #pragma mark - NSUserNotificationCenterDelegate
 
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
-     shouldPresentNotification:(NSUserNotification *)notification
-{
+     shouldPresentNotification:(NSUserNotification *)notification {
     return YES;
 }
 
 #pragma mark -
 
-- (void)notifyUserWithTitle:(NSString * _Nullable)title text:(NSString * _Nullable)text {
+- (void)notifyUserWithTitle:(NSString *_Nullable)title text:(NSString *_Nullable)text {
     NSUserNotification *notification = [[NSUserNotification alloc] init];
+
     notification.title = title;
     notification.informativeText = text;
     [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
 }
 
-- (void)notifyUserWithText:(NSString * _Nullable)text {
+- (void)notifyUserWithText:(NSString *_Nullable)text {
     [self notifyUserWithTitle:@"Kube Solo" text:text];
 }
 

--- a/src/Kube-Solo/AppDelegate.m
+++ b/src/Kube-Solo/AppDelegate.m
@@ -65,7 +65,6 @@
 
     switch (vmStatus) {
         case VMStatusDown: {
-            NSLog(@"VM is Off");
             BOOL isDir;
             if ([[NSFileManager defaultManager] fileExistsAtPath:[[NSURL ks_homeURL] path] isDirectory:&isDir] && isDir) {
                 [self notifyUserWithTitle:@"Kube Solo will be up shortly" text:@"and OS shell will be opened"];
@@ -94,7 +93,6 @@
         }
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM is already running !!!"];
             break;
     }
@@ -105,11 +103,9 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is already Off !!!"];
             break;
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be stopped"];
             [self.vmManager halt];
             [self notifyUserWithText:@"VM is stopping !!!"];
@@ -134,12 +130,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be reloaded"];
             [self.vmManager reload];
             break;
@@ -151,12 +145,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithTitle:@"Kube-Solo and" text:@"OS X kubectl will be updated"];
             [self.vmManager updateKubernetes];
             break;
@@ -184,12 +176,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"OS X clients will be updated"];
             [self.vmManager updateClients];
             break;
@@ -255,12 +245,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM's console will be opened"];
             [self.vmManager attachConsole];
             break;
@@ -272,12 +260,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"OS X shell will be opened"];
             [self.vmManager runShell];
             break;
@@ -289,12 +275,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM ssh shell will be opened"];
             [self.vmManager runSSH];
             break;
@@ -306,12 +290,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:3000", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
@@ -324,12 +306,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:8080/ui", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
@@ -342,12 +322,10 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             [self notifyUserWithText:@"VM is Off !!!"];
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             NSString *vmIP = [NSString stringWithContentsOfURL:[NSURL ks_ipAddressURL] encoding:NSUTF8StringEncoding error:nil];
             NSString *url = [NSString stringWithFormat:@"http://%@:4194", vmIP];
             [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
@@ -360,11 +338,9 @@
 
     switch (vmStatus) {
         case VMStatusDown:
-            NSLog(@"VM is Off");
             break;
 
         case VMStatusUp:
-            NSLog(@"VM is On");
             [self notifyUserWithText:@"VM will be stopped"];
             [self.vmManager halt];
             [self notifyUserWithText:@"VM is stopping !!!"];

--- a/src/Kube-Solo/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/src/Kube-Solo/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -13,8 +13,9 @@
       "scale" : "2x"
     },
     {
-      "idiom" : "mac",
       "size" : "32x32",
+      "idiom" : "mac",
+      "filename" : "icon-32x32.png",
       "scale" : "1x"
     },
     {
@@ -36,8 +37,9 @@
       "scale" : "2x"
     },
     {
-      "idiom" : "mac",
       "size" : "256x256",
+      "idiom" : "mac",
+      "filename" : "icon-256x256.png",
       "scale" : "1x"
     },
     {
@@ -47,35 +49,15 @@
       "scale" : "2x"
     },
     {
-      "idiom" : "mac",
       "size" : "512x512",
+      "idiom" : "mac",
+      "filename" : "icon-512x512.png",
       "scale" : "1x"
     },
     {
       "size" : "512x512",
       "idiom" : "mac",
       "filename" : "icon-512x512@2x.png",
-      "scale" : "2x"
-    },
-    {
-      "size" : "16x16",
-      "idiom" : "mac",
-      "filename" : "icon-32x32.png",
-      "unassigned" : true,
-      "scale" : "2x"
-    },
-    {
-      "size" : "128x128",
-      "idiom" : "mac",
-      "filename" : "icon-256x256.png",
-      "unassigned" : true,
-      "scale" : "2x"
-    },
-    {
-      "size" : "256x256",
-      "idiom" : "mac",
-      "filename" : "icon-512x512.png",
-      "unassigned" : true,
       "scale" : "2x"
     }
   ],

--- a/src/Kube-Solo/NSURL+KubeSolo.h
+++ b/src/Kube-Solo/NSURL+KubeSolo.h
@@ -1,0 +1,19 @@
+//
+//  NSURL+KubeSolo.h
+//  Kube-Solo
+//
+//  Created by Brandon Evans on 2015-10-28.
+//  Copyright © 2015 Rimantas Mocevicius. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURL (KubeSolo)
+
++ (instancetype)ks_homeURL;
++ (instancetype)ks_envURL;
++ (instancetype)ks_resourcePathURL;
++ (instancetype)ks_appVersionURL;
++ (instancetype)ks_ipAddressURL;
+
+@end

--- a/src/Kube-Solo/NSURL+KubeSolo.m
+++ b/src/Kube-Solo/NSURL+KubeSolo.m
@@ -1,0 +1,33 @@
+//
+//  NSURL+KubeSolo.m
+//  Kube-Solo
+//
+//  Created by Brandon Evans on 2015-10-28.
+//  Copyright © 2015 Rimantas Mocevicius. All rights reserved.
+//
+
+#import "NSURL+KubeSolo.h"
+
+@implementation NSURL (KubeSolo)
+
++ (instancetype)ks_homeURL {
+    return [[NSURL fileURLWithPath:NSHomeDirectory()] URLByAppendingPathComponent:@"kube-solo/"];
+}
+
++ (instancetype)ks_envURL {
+    return [[self ks_homeURL] URLByAppendingPathComponent:@".env/"];
+}
+
++ (instancetype)ks_resourcePathURL {
+    return [[self ks_envURL] URLByAppendingPathComponent:@"resouce_path"];
+}
+
++ (instancetype)ks_appVersionURL {
+    return [[self ks_envURL] URLByAppendingPathComponent:@"version"];
+}
+
++ (instancetype)ks_ipAddressURL {
+    return [[self ks_envURL] URLByAppendingPathComponent:@"ip_address"];
+}
+
+@end

--- a/src/Kube-Solo/VMManager.h
+++ b/src/Kube-Solo/VMManager.h
@@ -16,6 +16,19 @@ typedef NS_ENUM(NSInteger, VMStatus) {
 @interface VMManager : NSObject
 
 - (VMStatus)checkVMStatus;
-- (void)showVMStatus;
+- (void)start;
+- (void)halt;
+- (void)kill;
+- (void)reload;
+- (void)updateKubernetes;
+- (void)updateKubernetesVersion;
+- (void)updateClients;
+- (void)updateISO;
+- (void)changeReleaseChannel;
+- (void)destroy;
+- (void)install;
+- (void)attachConsole;
+- (void)runShell;
+- (void)runSSH;
 
 @end

--- a/src/Kube-Solo/VMManager.h
+++ b/src/Kube-Solo/VMManager.h
@@ -1,0 +1,21 @@
+//
+//  VMManager.h
+//  Kube-Solo
+//
+//  Created by Brandon Evans on 2015-10-28.
+//  Copyright © 2015 Rimantas Mocevicius. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, VMStatus) {
+    VMStatusDown = 0,
+    VMStatusUp = 1
+};
+
+@interface VMManager : NSObject
+
+- (VMStatus)checkVMStatus;
+- (void)showVMStatus;
+
+@end

--- a/src/Kube-Solo/VMManager.m
+++ b/src/Kube-Solo/VMManager.m
@@ -1,0 +1,72 @@
+//
+//  VMManager.m
+//  Kube-Solo
+//
+//  Created by Brandon Evans on 2015-10-28.
+//  Copyright © 2015 Rimantas Mocevicius. All rights reserved.
+//
+
+#import "VMManager.h"
+
+@implementation VMManager
+
+- (VMStatus)checkVMStatus {
+    // check VM status and return the shell script output
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:@"check_vm_status" ofType:@"command"]];
+    //    task.arguments  = @[@"status"];
+
+    NSPipe *pipe;
+    pipe = [NSPipe pipe];
+    [task setStandardOutput: pipe];
+
+    NSFileHandle *file;
+    file = [pipe fileHandleForReading];
+
+    [task launch];
+    [task waitUntilExit];
+
+    NSData *data;
+    data = [file readDataToEndOfFile];
+
+    NSString *string;
+    string = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+    NSLog (@"Show VM status:\n%@", string);
+
+    if ( [string isEqual: @"VM is stopped"] ) {
+        return VMStatusDown;
+    } else {
+        return VMStatusUp;
+    }
+}
+
+- (void)showVMStatus {
+    // check vm status and return the shell script output
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:@"check_vm_status" ofType:@"command"]];
+    //    task.arguments  = @[@"status"];
+
+    NSPipe *pipe;
+    pipe = [NSPipe pipe];
+    [task setStandardOutput: pipe];
+
+    NSFileHandle *file;
+    file = [pipe fileHandleForReading];
+
+    [task launch];
+    [task waitUntilExit];
+
+    NSData *data;
+    data = [file readDataToEndOfFile];
+
+    NSString *string;
+    string = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+    //NSLog (@"Returned:\n%@", string);
+
+    // send a notification on to the screen
+    NSUserNotification *notification = [[NSUserNotification alloc] init];
+    notification.informativeText = string;
+    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
+@end

--- a/src/Kube-Solo/VMManager.m
+++ b/src/Kube-Solo/VMManager.m
@@ -18,7 +18,7 @@
 
     NSPipe *pipe;
     pipe = [NSPipe pipe];
-    [task setStandardOutput: pipe];
+    [task setStandardOutput:pipe];
 
     NSFileHandle *file;
     file = [pipe fileHandleForReading];
@@ -30,10 +30,10 @@
     data = [file readDataToEndOfFile];
 
     NSString *string;
-    string = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
-    NSLog (@"Show VM status:\n%@", string);
+    string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSLog(@"Show VM status:\n%@", string);
 
-    if ( [string isEqual: @"VM is stopped"] ) {
+    if ([string isEqual:@"VM is stopped"]) {
         NSLog(@"VM is Off");
         return VMStatusDown;
     } else {
@@ -74,7 +74,7 @@
     NSTask *task = [[NSTask alloc] init];
 
     task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:scriptName ofType:@"command"]];
-    task.arguments  = @[arguments];
+    task.arguments = @[ arguments ];
     [task launch];
     [task waitUntilExit];
 }

--- a/src/Kube-Solo/VMManager.m
+++ b/src/Kube-Solo/VMManager.m
@@ -34,8 +34,10 @@
     NSLog (@"Show VM status:\n%@", string);
 
     if ( [string isEqual: @"VM is stopped"] ) {
+        NSLog(@"VM is Off");
         return VMStatusDown;
     } else {
+        NSLog(@"VM is On");
         return VMStatusUp;
     }
 }

--- a/src/Kube-Solo/VMManager.m
+++ b/src/Kube-Solo/VMManager.m
@@ -40,33 +40,74 @@
     }
 }
 
-- (void)showVMStatus {
-    // check vm status and return the shell script output
+- (void)start {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"up.command"]];
+}
+
+- (void)halt {
+    [self runScript:@"halt" arguments:@""];
+}
+
+- (void)kill {
+    [self runScript:@"kill_VM" arguments:@""];
+}
+
+- (void)reload {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"reload.command"]];
+}
+
+- (void)updateKubernetes {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_k8s.command"]];
+}
+
+- (void)updateKubernetesVersion {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_k8s_version.command"]];
+}
+
+- (void)updateClients {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"update_osx_clients_files.command"]];
+}
+
+- (void)runScript:(NSString *)scriptName arguments:(NSString *)arguments {
     NSTask *task = [[NSTask alloc] init];
-    task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:@"check_vm_status" ofType:@"command"]];
-    //    task.arguments  = @[@"status"];
 
-    NSPipe *pipe;
-    pipe = [NSPipe pipe];
-    [task setStandardOutput: pipe];
-
-    NSFileHandle *file;
-    file = [pipe fileHandleForReading];
-
+    task.launchPath = [NSString stringWithFormat:@"%@", [[NSBundle mainBundle] pathForResource:scriptName ofType:@"command"]];
+    task.arguments  = @[arguments];
     [task launch];
     [task waitUntilExit];
+}
 
-    NSData *data;
-    data = [file readDataToEndOfFile];
+- (void)runApp:(NSString *)appName arguments:(NSString *)arguments {
+    // lunch an external App from the mainBundle
+    [[NSWorkspace sharedWorkspace] openFile:arguments withApplication:appName];
+}
 
-    NSString *string;
-    string = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
-    //NSLog (@"Returned:\n%@", string);
+- (void)updateISO {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"fetch_latest_iso.command"]];
+}
 
-    // send a notification on to the screen
-    NSUserNotification *notification = [[NSUserNotification alloc] init];
-    notification.informativeText = string;
-    [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+- (void)changeReleaseChannel {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"change_release_channel.command"]];
+}
+
+- (void)destroy {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"destroy.command"]];
+}
+
+- (void)install {
+    [self runScript:@"kube-solo-install" arguments:[[NSBundle mainBundle] resourcePath]];
+}
+
+- (void)attachConsole {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"console.command"]];
+}
+
+- (void)runShell {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"os_shell.command"]];
+}
+
+- (void)runSSH {
+    [self runApp:@"iTerm" arguments:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"ssh.command"]];
 }
 
 @end

--- a/src/Kube-Solo/en.lproj/Localizable.strings
+++ b/src/Kube-Solo/en.lproj/Localizable.strings
@@ -1,0 +1,48 @@
+/* 
+  Localizable.strings
+  Kube-Solo
+
+  Created by Brandon Evans on 2015-10-28.
+  Copyright © 2015 Rimantas Mocevicius. All rights reserved.
+*/
+
+"AppName" = "Kube-Solo";
+"OK" = "OK";
+"Cancel" = "Cancel";
+
+// VM States
+
+"VMStateAlreadyRunning" = "VM is already running !!!";
+"VMStateAlreadyOff" = "VM is already Off !!!";
+"VMStateWillStop" = "VM will be stopped";
+"VMStateStopping" = "VM is stopping !!!";
+"VMStateOff" = "VM is OFF !!!";
+"VMStateWillReload" = "VM will be reloaded";
+"VMStateStopped" = "VM is stopped";
+"VMStateRunning" = "VM is running";
+"VMStateWillDestroy" = "VM will be destroyed";
+
+// Notification Messages
+
+"ClientsWillBeUpdatedNotificationMessage" = "OS X clients will be updated";
+"ISOImageWillBeUpdatedNotificationMessage" = "CoreOS ISO image will be updated";
+"ReleaseChannelChangeNotificationMessage" = "CoreOS release channel change";
+"SSHShellWillOpenNotificationMessage" = "VM ssh shell will be opened";
+"ShellWillOpenNotificationMessage" = "OS X shell will be opened";
+"ConsoleWillOpenNotificationMessage" = "VM's console will be opened";
+"WillSetupNotificationTitle" = "Kube Solo will be up shortly";
+"WillSetupNotificationMessage" = "and OS shell will be opened";
+"KubernetesUpdateNotificationTitle" = "Kube-Solo and";
+"KubernetedUpdateNotificationMessage" = "OS X kubectl will be updated";
+"KubernetesVersionChangeNotificationMessage" = "OS X kubectl version will be changed";
+"QuittingNotificationTitle" = "Quitting Kube-Solo App";
+
+// Alerts
+
+"NotSetupAlertMessage" = "Kube Solo was not setup";
+"NotSetupAlertInformativeText" = "Do you want to set it up?";
+"SetupAlertMessage" = "You can set Kube-Solo from menu 'Setup':";
+"SetupAlertInformativeText" = " 'Initial setup of Kube-Solo' at any time later one !!! ";
+"HomeFolderExistsAlertInformativeText" = "Folder %@ exists, please delete or rename that folder !!!";
+"AboutAlertMessage" = "Kube-Solo for OS X v%@";
+"AboutInformativeText" = "It is a simple wrapper around xhyve + CoreOS VM, which allows to control Kube-Solo via Status Bar !!!";


### PR DESCRIPTION
Sorry in advance, the diffs for this PR are pretty involved and I understand if you don't want to merge it. :smile:

What this changes:
- Extracts VM manipulation code into a VMManager class
- Specifies all app-specific filesystem paths in a NSURL category
- Adds support for localization of all user-facing strings
- Some code style and variable name changes for consistency and Cocoa conventions

Why:

I think this is a step towards making it easier to test the little bit of logic that is handled in the Objective-C part of the app, and adopts some Cocoa conventions. These changes could also be applied to some of the other similar projects you have.

Thanks for making this project! I really appreciate how easy it makes it to get Kubernetes running locally on a Mac.
