### PR TITLE
Allow custom kubeconfig location for kubectl

### DIFF
--- a/src/bin/kubectl
+++ b/src/bin/kubectl
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-cmd=($HOME/kube-solo/kube/kubectl --kubeconfig="$HOME/kube-solo/kube/kubeconfig" "${@+$@}")
+cmd=($HOME/kube-solo/kube/kubectl --kubeconfig="${KUBE_CONFIG:-$HOME/kube-solo/kube/kubeconfig}" "${@+$@}")
 
 "${cmd[@]}"


### PR DESCRIPTION
Every time the kube-solo VM is brought up, the kubectl wrapper is
regenerated.  This means that any customizations you make to this file,
like the location of the kubectl configuration, is overwritten.  This
commit will allow people to use an environment variable to point where
the kubectl wrapper finds the kubectl configuration file instead of us
having to update the wrapper each time the VM is brought up.
