### PR TITLE
Use overlay2 driver

### DIFF
--- a/src/cloud-init/user-data
+++ b/src/cloud-init/user-data
@@ -123,7 +123,7 @@ coreos:
             [Unit]
             Requires=flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='--insecure-registry="0.0.0.0/0" --storage-driver="overlay2"'
+            Environment="DOCKER_OPTS=--insecure-registry=0.0.0.0/0 --storage-driver=overlay2"
     - name: update-engine.service
       command: stop
     - name: kube-certs.service

--- a/src/cloud-init/user-data
+++ b/src/cloud-init/user-data
@@ -123,7 +123,7 @@ coreos:
             [Unit]
             Requires=flanneld.service
             [Service]
-            Environment=DOCKER_OPTS='--insecure-registry="0.0.0.0/0"'
+            Environment=DOCKER_OPTS='--insecure-registry="0.0.0.0/0" --storage-driver="overlay2"'
     - name: update-engine.service
       command: stop
     - name: kube-certs.service


### PR DESCRIPTION
From https://docs.docker.com/engine/userguide/storagedriver/selectadriver/#overlay-vs-overlay2, there are serious issues with the overlay driver, and both the kernel and the stable version of docker engine support the newer driver, so it should be the default.